### PR TITLE
Fsdev small packet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ latex
 test_old/
 tests_obsolete/
 _build
+# coverity intermediate files
+cov-int
+# cppcheck build directories
+*-build-dir

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -258,12 +258,8 @@ void dcd_int_enable (uint8_t rhport)
 {
   (void)rhport;
 #if defined(STM32F0)
-  NVIC_SetPriority(USB_IRQn, 0);
   NVIC_EnableIRQ(USB_IRQn);
 #elif defined(STM32F3)
-  NVIC_SetPriority(USB_HP_CAN_TX_IRQn, 0);
-  NVIC_SetPriority(USB_LP_CAN_RX0_IRQn, 0);
-  NVIC_SetPriority(USBWakeUp_IRQn, 0);
   NVIC_EnableIRQ(USB_HP_CAN_TX_IRQn);
   NVIC_EnableIRQ(USB_LP_CAN_RX0_IRQn);
   NVIC_EnableIRQ(USBWakeUp_IRQn);
@@ -283,6 +279,10 @@ void dcd_int_disable(uint8_t rhport)
 #else
 #error Unknown arch in USB driver
 #endif
+  // I'm not convinced that memory synchronization is completely necessary, but
+  // it isn't a bad idea.
+  __DSB();
+  __ISB();
 }
 
 // Receive Set Address request, mcu port must also include status IN response

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -121,6 +121,7 @@
 #undef USE_HAL_DRIVER
 
 #include "device/dcd.h"
+#include "bsp/board.h"
 #include "portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h"
 
 

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -595,7 +595,7 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc
   if(dir == TUSB_DIR_IN)
   {
     *PCD_EP_TX_ADDRESS_PTR(USB, epnum) = ep_buf_ptr;
-    PCD_SET_EP_RX_CNT(USB, epnum, p_endpoint_desc->wMaxPacketSize.size);
+    PCD_SET_EP_TX_CNT(USB, epnum, p_endpoint_desc->wMaxPacketSize.size);
     PCD_CLEAR_TX_DTOG(USB, epnum);
     PCD_SET_EP_TX_STATUS(USB,epnum,USB_EP_TX_NAK);
   }

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -165,7 +165,7 @@ typedef struct
 
 static xfer_ctl_t xfer_status[MAX_EP_COUNT][2];
 
-static xfer_ctl_t* xfer_ctl_ptr(unsigned int epnum, unsigned int dir)
+static xfer_ctl_t* xfer_ctl_ptr(uint32_t epnum, uint32_t dir)
 {
 #ifndef NDEBUG
   TU_ASSERT(epnum < MAX_EP_COUNT);
@@ -354,7 +354,7 @@ static void dcd_handle_bus_reset(void)
 // FIXME: Defined to return uint16 so that ASSERT can be used, even though a return value is not needed.
 static uint16_t dcd_ep_ctr_handler(void)
 {
-  unsigned int count=0U;
+  uint32_t count=0U;
   uint8_t EPindex;
   __IO uint16_t wIstr;
   __IO uint16_t wEPVal = 0U;

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -46,7 +46,7 @@
     defined(STM32F072xB) | \
     defined(STM32F078xx)
 #include "stm32f0xx.h"
-#define PMA_LENGTH 1024
+#define PMA_LENGTH (1024u)
 // F0x2 models are crystal-less
 // All have internal D+ pull-up
 // 070RB:    2 x 16 bits/word memory     LPM Support, BCD Support
@@ -55,7 +55,7 @@
       defined(STM32F103x6) | defined(STM32F103xB) | \
       defined(STM32F103xE) | defined(STM32F103xB)
 #include "stm32f1xx.h"
-#define PMA_LENGTH 512u
+#define PMA_LENGTH (512u)
 // NO internal Pull-ups
 //         *B, and *C:    2 x 16 bits/word
 #error The F102/F103 driver is expected not to work, but it might? Try it?
@@ -64,7 +64,7 @@
       defined(STM32F303xB) | defined(STM32F303xC) | \
       defined(STM32F373xC)
 #include "stm32f3xx.h"
-#define PMA_LENGTH 512u
+#define PMA_LENGTH (512u)
 // NO internal Pull-ups
 //         *B, and *C:    1 x 16 bits/word
 // PMA dedicated to USB (no sharing with CAN)
@@ -72,7 +72,7 @@
       defined(STM32F302xD) | defined(STM32F302xE) | \
       defined(STM32F303xD) | defined(STM32F303xE) | \
 #include "stm32f3xx.h"
-#define PMA_LENGTH 1024u
+#define PMA_LENGTH (1024u)
 // NO internal Pull-ups
 // *6, *8, *D, and *E:    2 x 16 bits/word     LPM Support
 // When CAN clock is enabled, USB can use first 768 bytes ONLY.
@@ -83,9 +83,9 @@
 
 // For purposes of accessing the packet
 #if ((PMA_LENGTH) == 512u)
-const size_t PMA_STRIDE = 2u;
+#define PMA_STRIDE  (2u)
 #elif ((PMA_LENGTH) == 1024u)
-const size_t PMA_STRIDE = 1u;
+#define PMA_STRIDE  (1u)
 #endif
 
 // And for type-safety create a new macro for the volatile address of PMAADDR

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -83,9 +83,9 @@
 
 // For purposes of accessing the packet
 #if ((PMA_LENGTH) == 512u)
-#  define PMA_STRIDE (2u)
+const size_t PMA_STRIDE = 2u;
 #elif ((PMA_LENGTH) == 1024u)
-#  define PMA_STRIDE (1u)
+const size_t PMA_STRIDE = 1u;
 #endif
 
 // And for type-safety create a new macro for the volatile address of PMAADDR
@@ -93,32 +93,75 @@
 // Volatile is also needed to prevent the optimizer from changing access to 32-bit (as 32-bit access is forbidden)
 static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
 
-/* SetENDPOINT */
-#define PCD_SET_ENDPOINT(USBx, bEpNum,wRegValue)  (*((__IO uint16_t *)(((uint32_t)(&(USBx)->EP0R + (bEpNum) * 2U))))= (uint16_t)(wRegValue))
-/* GetENDPOINT */
-#define PCD_GET_ENDPOINT(USBx, bEpNum)            (*((__IO uint16_t *)(((uint32_t)(&(USBx)->EP0R + (bEpNum) * 2U)))))
-#define PCD_SET_EPTYPE(USBx, bEpNum,wType) (PCD_SET_ENDPOINT((USBx), (bEpNum),\
-                                  (((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & ((uint32_t)(USB_EP_T_MASK))) | ((uint32_t)(wType))) | USB_EP_CTR_RX | USB_EP_CTR_TX)))
-#define PCD_GET_EPTYPE(USBx, bEpNum) (((uint16_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EP_T_FIELD)
+// prototypes
+static inline __IO uint16_t* pcd_ep_rx_cnt_ptr(USB_TypeDef * USBx, unsigned int bEpNum);
+static inline __IO uint16_t* pcd_ep_tx_cnt_ptr(USB_TypeDef * USBx, unsigned int bEpNum);
+static inline void pcd_set_endpoint(USB_TypeDef * USBx, unsigned int bEpNum, unsigned int wRegValue);
 
+
+/* SetENDPOINT */
+static inline void pcd_set_endpoint(USB_TypeDef * USBx, unsigned int bEpNum, unsigned int wRegValue)
+{
+  __O uint16_t *reg = (__O uint16_t *)((&USBx->EP0R) + bEpNum*2u);
+  *reg = (uint16_t)wRegValue;
+}
+
+/* GetENDPOINT */
+static inline uint16_t pcd_get_endpoint(USB_TypeDef * USBx, unsigned int bEpNum) {
+  __I uint16_t *reg = (__I uint16_t *)((&USBx->EP0R) + bEpNum*2u);
+  return *reg;
+}
+
+static inline void pcd_set_eptype(USB_TypeDef * USBx, unsigned int bEpNum, unsigned int wType)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= (uint32_t)USB_EP_T_MASK;
+  regVal |= wType;
+  regVal |= USB_EP_CTR_RX | USB_EP_CTR_TX; // These clear on write0, so must set high
+  pcd_set_endpoint(USBx, bEpNum, regVal);
+}
+
+static inline unsigned int pcd_get_eptype(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= USB_EP_T_FIELD;
+  return regVal;
+}
 /**
   * @brief  Clears bit CTR_RX / CTR_TX in the endpoint register.
   * @param  USBx USB peripheral instance register address.
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-#define PCD_CLEAR_RX_EP_CTR(USBx, bEpNum)   (PCD_SET_ENDPOINT((USBx), (bEpNum),\
-                                   PCD_GET_ENDPOINT((USBx), (bEpNum)) & 0x7FFFU & USB_EPREG_MASK))
-#define PCD_CLEAR_TX_EP_CTR(USBx, bEpNum)   (PCD_SET_ENDPOINT((USBx), (bEpNum),\
-                                   PCD_GET_ENDPOINT((USBx), (bEpNum)) & 0xFF7FU & USB_EPREG_MASK))
+static inline void pcd_clear_rx_ep_ctr(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= 0x7FFFu & USB_EPREG_MASK;
+  pcd_set_endpoint(USBx, bEpNum, regVal);
+}
+static inline void pcd_clear_tx_ep_ctr(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= regVal & 0xFF7FU & USB_EPREG_MASK;
+  pcd_set_endpoint(USBx, bEpNum,regVal);
+}
 /**
   * @brief  gets counter of the tx buffer.
   * @param  USBx USB peripheral instance register address.
   * @param  bEpNum Endpoint Number.
   * @retval Counter value
   */
-#define PCD_GET_EP_TX_CNT(USBx, bEpNum)((uint16_t)(*PCD_EP_TX_CNT_PTR((USBx), (bEpNum))) & 0x3ffU)
-#define PCD_GET_EP_RX_CNT(USBx, bEpNum)((uint16_t)(*PCD_EP_RX_CNT_PTR((USBx), (bEpNum))) & 0x3ffU)
+static inline unsigned int pcd_get_ep_tx_cnt(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  __I uint16_t *regPtr = pcd_ep_tx_cnt_ptr(USBx, bEpNum);
+  return *regPtr & 0x3ffU;
+}
+
+static inline unsigned int pcd_get_ep_rx_cnt(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  __I uint16_t *regPtr = pcd_ep_rx_cnt_ptr(USBx, bEpNum);
+  return *regPtr & 0x3ffU;
+}
 
 /**
   * @brief  Sets counter of rx buffer with no. of blocks.
@@ -127,38 +170,30 @@ static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
   * @param  wNBlocks no. of Blocks.
   * @retval None
   */
-#define PCD_CALC_BLK32(dwReg,wCount,wNBlocks) {\
-    (wNBlocks) = (uint32_t)((wCount) >> 5U);\
-    if(((wCount) & 0x1fU) == 0U)\
-    {                                                  \
-      (wNBlocks)--;\
-    }                                                  \
-    *pdwReg = (uint16_t)((uint16_t)((wNBlocks) << 10U) | (uint16_t)0x8000U); \
-  }/* PCD_CALC_BLK32 */
 
-
-#define PCD_CALC_BLK2(dwReg,wCount,wNBlocks) {\
-    (wNBlocks) = (uint32_t)((wCount) >> 1U); \
-    if(((wCount) & 0x1U) != 0U)\
-    {                                                  \
-      (wNBlocks)++;\
-    }                                                  \
-    *pdwReg = (uint16_t)((wNBlocks) << 10U);\
-  }/* PCD_CALC_BLK2 */
-
-
-#define PCD_SET_EP_CNT_RX_REG(dwReg,wCount)  {\
-    uint32_t wNBlocks;\
-    if((wCount) > 62U)                                \
-    {                                                \
-      PCD_CALC_BLK32((dwReg),(wCount),wNBlocks)     \
-    }                                                \
-    else                                             \
-    {                                                \
-      PCD_CALC_BLK2((dwReg),(wCount),wNBlocks)     \
-    }                                                \
-  }/* PCD_SET_EP_CNT_RX_REG */
-
+static inline void pcd_set_ep_cnt_rx_reg(__O uint16_t * pdwReg, size_t wCount)  {
+  unsigned int wNBlocks;
+  if(wCount > 62u)
+  {
+    wNBlocks = wCount >> 5u;
+    if((wCount & 0x1fU) == 0u)
+    {
+      wNBlocks--;
+    }
+    wNBlocks = wNBlocks << 10u;
+    wNBlocks |= 0x8000u; // Mark block size as 32byte
+    *pdwReg = (uint16_t)wNBlocks;
+  }
+  else
+  {
+    wNBlocks = wCount >> 1u;
+    if((wCount & 0x1U) != 0u)
+    {
+      wNBlocks++;
+    }
+    *pdwReg = (uint16_t)((wNBlocks) << 10u);
+  }
+}
 
 
 /**
@@ -168,23 +203,52 @@ static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
   * @param  bAddr Address.
   * @retval None
   */
-#define PCD_SET_EP_ADDRESS(USBx, bEpNum,bAddr) PCD_SET_ENDPOINT((USBx), (bEpNum),\
-    USB_EP_CTR_RX|USB_EP_CTR_TX|(((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPREG_MASK) | (bAddr))
+static inline void pcd_set_ep_address(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int bAddr)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= USB_EPREG_MASK;
+  regVal |= bAddr;
+  regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX;
+  pcd_set_endpoint(USBx, bEpNum,regVal);
+}
 
-#define PCD_BTABLE_WORD_PTR(USBx,x) (&(pma[PMA_STRIDE*((((USBx)->BTABLE)>>1) + x)]))
+static inline __IO uint16_t * pcd_btable_word_ptr(USB_TypeDef * USBx, size_t x)
+{
+  size_t total_word_offset = (((USBx)->BTABLE)>>1) + x;
+  total_word_offset *= PMA_STRIDE;
+  return &(pma[total_word_offset]);
+}
 
 // Pointers to the PMA table entries (using the ARM address space)
-#define PCD_EP_TX_ADDRESS_PTR(USBx, bEpNum) (PCD_BTABLE_WORD_PTR(USBx,(bEpNum)*4u + 0u))
-#define PCD_EP_TX_CNT_PTR(USBx, bEpNum)     (PCD_BTABLE_WORD_PTR(USBx,(bEpNum)*4u + 1u))
+static inline __IO uint16_t* pcd_ep_tx_address_ptr(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  return pcd_btable_word_ptr(USBx,(bEpNum)*4u + 0u);
+}
+static inline __IO uint16_t* pcd_ep_tx_cnt_ptr(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  return pcd_btable_word_ptr(USBx,(bEpNum)*4u + 1u);
+}
 
-#define PCD_EP_RX_ADDRESS_PTR(USBx, bEpNum) (PCD_BTABLE_WORD_PTR(USBx,(bEpNum)*4u + 2u))
-#define PCD_EP_RX_CNT_PTR(USBx, bEpNum)     (PCD_BTABLE_WORD_PTR(USBx,(bEpNum)*4u + 3u))
+static inline __IO uint16_t* pcd_ep_rx_address_ptr(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  return  pcd_btable_word_ptr(USBx,(bEpNum)*4u + 2u);
+}
 
-#define PCD_SET_EP_TX_CNT(USBx, bEpNum,wCount) (*PCD_EP_TX_CNT_PTR((USBx), (bEpNum)) = (wCount))
-#define PCD_SET_EP_RX_CNT(USBx, bEpNum,wCount) do {\
-    __IO uint16_t *pdwReg =PCD_EP_RX_CNT_PTR((USBx),(bEpNum)); \
-    PCD_SET_EP_CNT_RX_REG((pdwReg), (wCount))\
-  } while(0)
+static inline __IO uint16_t* pcd_ep_rx_cnt_ptr(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  return pcd_btable_word_ptr(USBx,(bEpNum)*4u + 3u);
+}
+
+static inline void pcd_set_ep_tx_cnt(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int wCount)
+{
+  *pcd_ep_tx_cnt_ptr(USBx, bEpNum) = (uint16_t)wCount;
+}
+
+static inline void pcd_set_ep_rx_cnt(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int wCount)
+{
+  __IO uint16_t *pdwReg = pcd_ep_rx_cnt_ptr((USBx),(bEpNum));
+  pcd_set_ep_cnt_rx_reg(pdwReg, wCount);
+}
 
 /**
   * @brief  sets the status for tx transfer (bits STAT_TX[1:0]).
@@ -193,21 +257,24 @@ static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
   * @param  wState new state
   * @retval None
   */
-#define PCD_SET_EP_TX_STATUS(USBx, bEpNum, wState) { register uint16_t _wRegVal;\
-   \
-    _wRegVal = (uint32_t) (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPTX_DTOGMASK);\
-   /* toggle first bit ? */     \
-   if((USB_EPTX_DTOG1 & (wState))!= 0U)\
-   {                                                                            \
-     _wRegVal ^=(uint16_t) USB_EPTX_DTOG1;        \
-   }                                                                            \
-   /* toggle second bit ?  */         \
-   if((USB_EPTX_DTOG2 & ((uint32_t)(wState)))!= 0U)      \
-   {                                                                            \
-     _wRegVal ^=(uint16_t) USB_EPTX_DTOG2;        \
-   }                                                                            \
-   PCD_SET_ENDPOINT((USBx), (bEpNum), (((uint32_t)(_wRegVal)) | USB_EP_CTR_RX|USB_EP_CTR_TX));\
-  } /* PCD_SET_EP_TX_STATUS */
+static inline void pcd_set_ep_tx_status(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int wState)
+{
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= USB_EPTX_DTOGMASK;
+
+  /* toggle first bit ? */
+  if((USB_EPTX_DTOG1 & (wState))!= 0U)
+  {
+    regVal ^= USB_EPTX_DTOG1;
+  }
+  /* toggle second bit ?  */
+  if((USB_EPTX_DTOG2 & ((uint32_t)(wState)))!= 0U)
+  {
+    regVal ^= USB_EPTX_DTOG2;
+  }
+  regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX;
+  pcd_set_endpoint(USBx, bEpNum, regVal);
+} /* pcd_set_ep_tx_status */
 
 /**
   * @brief  sets the status for rx transfer (bits STAT_TX[1:0])
@@ -216,22 +283,25 @@ static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
   * @param  wState new state
   * @retval None
   */
-#define PCD_SET_EP_RX_STATUS(USBx, bEpNum,wState) {\
-    register uint16_t _wRegVal;   \
-    \
-    _wRegVal = (uint32_t) (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPRX_DTOGMASK);\
-    /* toggle first bit ? */  \
-    if((USB_EPRX_DTOG1 & (wState))!= 0U) \
-    {                                                                             \
-      _wRegVal ^= (uint16_t) USB_EPRX_DTOG1;  \
-    }                                                                             \
-    /* toggle second bit ? */  \
-    if((USB_EPRX_DTOG2 & ((uint32_t)(wState)))!= 0U) \
-    {                                                                             \
-      _wRegVal ^= (uint16_t) USB_EPRX_DTOG2;  \
-    }                                                                             \
-    PCD_SET_ENDPOINT((USBx), (bEpNum), (((uint32_t)(_wRegVal)) | USB_EP_CTR_RX|USB_EP_CTR_TX)); \
-  } /* PCD_SET_EP_RX_STATUS */
+
+static inline void pcd_set_ep_rx_status(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int wState)
+{
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= USB_EPRX_DTOGMASK;
+
+  /* toggle first bit ? */
+  if((USB_EPRX_DTOG1 & wState)!= 0U)
+  {
+    regVal ^= USB_EPRX_DTOG1;
+  }
+  /* toggle second bit ? */
+  if((USB_EPRX_DTOG2 & wState)!= 0U)
+  {
+    regVal ^= USB_EPRX_DTOG2;
+  }
+  regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX;
+  pcd_set_endpoint(USBx, bEpNum, regVal);
+} /* pcd_set_ep_rx_status */
 
 /**
   * @brief  Toggles DTOG_RX / DTOG_TX bit in the endpoint register.
@@ -239,10 +309,21 @@ static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-#define PCD_RX_DTOG(USBx, bEpNum)    (PCD_SET_ENDPOINT((USBx), (bEpNum), \
-                                   USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_RX | (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPREG_MASK)))
-#define PCD_TX_DTOG(USBx, bEpNum)    (PCD_SET_ENDPOINT((USBx), (bEpNum), \
-                                   USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_TX | (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPREG_MASK)))
+static inline void pcd_rx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= USB_EPREG_MASK;
+  regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_RX;
+  pcd_set_endpoint(USBx, bEpNum, regVal);
+}
+
+static inline void pcd_tx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= USB_EPREG_MASK;
+  regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_TX;
+  pcd_set_endpoint(USBx, bEpNum, regVal);
+}
 
 /**
   * @brief  Clears DTOG_RX / DTOG_TX bit in the endpoint register.
@@ -250,14 +331,24 @@ static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-#define PCD_CLEAR_RX_DTOG(USBx, bEpNum)  if((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EP_DTOG_RX) != 0)\
-                                         {                                                              \
-                                           PCD_RX_DTOG((USBx),(bEpNum));\
-                                         }
-#define PCD_CLEAR_TX_DTOG(USBx, bEpNum)  if((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EP_DTOG_TX) != 0)\
-                                         {\
-                                           PCD_TX_DTOG((USBx),(bEpNum));\
-                                         }
+
+static inline void pcd_clear_rx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  if((regVal & USB_EP_DTOG_RX) != 0)
+  {
+    pcd_rx_dtog(USBx,bEpNum);
+  }
+}
+
+static inline void pcd_clear_tx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  if((regVal & USB_EP_DTOG_TX) != 0)
+  {
+    pcd_tx_dtog(USBx,bEpNum);
+  }
+}
 
 /**
   * @brief  set & clear EP_KIND bit.
@@ -265,11 +356,22 @@ static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-#define PCD_SET_EP_KIND(USBx, bEpNum)    (PCD_SET_ENDPOINT((USBx), (bEpNum), \
-                                (USB_EP_CTR_RX|USB_EP_CTR_TX|((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) | USB_EP_KIND) & USB_EPREG_MASK))))
 
-#define PCD_CLEAR_EP_KIND(USBx, bEpNum)  (PCD_SET_ENDPOINT((USBx), (bEpNum), \
-                                (USB_EP_CTR_RX|USB_EP_CTR_TX|((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPKIND_MASK)))))
+static inline void pcd_set_ep_kind(USB_TypeDef * USBx,  unsigned int bEpNum)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal |= USB_EP_KIND;
+  regVal &= USB_EPREG_MASK;
+  regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX;
+  pcd_set_endpoint(USBx, bEpNum, regVal);
+}
+static inline void pcd_clear_ep_kind(USB_TypeDef * USBx, unsigned int bEpNum)
+{
+  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  regVal &= USB_EPKIND_MASK;
+  regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX;
+  pcd_set_endpoint(USBx, bEpNum, regVal);
+}
 
 // This checks if the device has "LPM"
 #if defined(USB_ISTR_L1REQ)
@@ -282,6 +384,6 @@ static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
      USB_ISTR_RESET | USB_ISTR_SOF | USB_ISTR_ESOF | USB_ISTR_L1REQ_FORCED )
 
 // Number of endpoints in hardware
-#define STFSDEV_EP_COUNT (8)
+#define STFSDEV_EP_COUNT (8u)
 
 #endif /* PORTABLE_ST_STM32F0_DCD_STM32F0_FSDEV_PVT_ST_H_ */

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev_pvt_st.h
@@ -94,36 +94,36 @@ const size_t PMA_STRIDE = 1u;
 static __IO uint16_t * const pma = (__IO uint16_t*)USB_PMAADDR;
 
 // prototypes
-static inline __IO uint16_t* pcd_ep_rx_cnt_ptr(USB_TypeDef * USBx, unsigned int bEpNum);
-static inline __IO uint16_t* pcd_ep_tx_cnt_ptr(USB_TypeDef * USBx, unsigned int bEpNum);
-static inline void pcd_set_endpoint(USB_TypeDef * USBx, unsigned int bEpNum, unsigned int wRegValue);
+static inline __IO uint16_t* pcd_ep_rx_cnt_ptr(USB_TypeDef * USBx, uint32_t bEpNum);
+static inline __IO uint16_t* pcd_ep_tx_cnt_ptr(USB_TypeDef * USBx, uint32_t bEpNum);
+static inline void pcd_set_endpoint(USB_TypeDef * USBx, uint32_t bEpNum, uint32_t wRegValue);
 
 
 /* SetENDPOINT */
-static inline void pcd_set_endpoint(USB_TypeDef * USBx, unsigned int bEpNum, unsigned int wRegValue)
+static inline void pcd_set_endpoint(USB_TypeDef * USBx, uint32_t bEpNum, uint32_t wRegValue)
 {
   __O uint16_t *reg = (__O uint16_t *)((&USBx->EP0R) + bEpNum*2u);
   *reg = (uint16_t)wRegValue;
 }
 
 /* GetENDPOINT */
-static inline uint16_t pcd_get_endpoint(USB_TypeDef * USBx, unsigned int bEpNum) {
+static inline uint16_t pcd_get_endpoint(USB_TypeDef * USBx, uint32_t bEpNum) {
   __I uint16_t *reg = (__I uint16_t *)((&USBx->EP0R) + bEpNum*2u);
   return *reg;
 }
 
-static inline void pcd_set_eptype(USB_TypeDef * USBx, unsigned int bEpNum, unsigned int wType)
+static inline void pcd_set_eptype(USB_TypeDef * USBx, uint32_t bEpNum, uint32_t wType)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= (uint32_t)USB_EP_T_MASK;
   regVal |= wType;
   regVal |= USB_EP_CTR_RX | USB_EP_CTR_TX; // These clear on write0, so must set high
   pcd_set_endpoint(USBx, bEpNum, regVal);
 }
 
-static inline unsigned int pcd_get_eptype(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline uint32_t pcd_get_eptype(USB_TypeDef * USBx, uint32_t bEpNum)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= USB_EP_T_FIELD;
   return regVal;
 }
@@ -133,15 +133,15 @@ static inline unsigned int pcd_get_eptype(USB_TypeDef * USBx, unsigned int bEpNu
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-static inline void pcd_clear_rx_ep_ctr(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline void pcd_clear_rx_ep_ctr(USB_TypeDef * USBx, uint32_t bEpNum)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= 0x7FFFu & USB_EPREG_MASK;
   pcd_set_endpoint(USBx, bEpNum, regVal);
 }
-static inline void pcd_clear_tx_ep_ctr(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline void pcd_clear_tx_ep_ctr(USB_TypeDef * USBx, uint32_t bEpNum)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= regVal & 0xFF7FU & USB_EPREG_MASK;
   pcd_set_endpoint(USBx, bEpNum,regVal);
 }
@@ -151,13 +151,13 @@ static inline void pcd_clear_tx_ep_ctr(USB_TypeDef * USBx, unsigned int bEpNum)
   * @param  bEpNum Endpoint Number.
   * @retval Counter value
   */
-static inline unsigned int pcd_get_ep_tx_cnt(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline uint32_t pcd_get_ep_tx_cnt(USB_TypeDef * USBx, uint32_t bEpNum)
 {
   __I uint16_t *regPtr = pcd_ep_tx_cnt_ptr(USBx, bEpNum);
   return *regPtr & 0x3ffU;
 }
 
-static inline unsigned int pcd_get_ep_rx_cnt(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline uint32_t pcd_get_ep_rx_cnt(USB_TypeDef * USBx, uint32_t bEpNum)
 {
   __I uint16_t *regPtr = pcd_ep_rx_cnt_ptr(USBx, bEpNum);
   return *regPtr & 0x3ffU;
@@ -172,7 +172,7 @@ static inline unsigned int pcd_get_ep_rx_cnt(USB_TypeDef * USBx, unsigned int bE
   */
 
 static inline void pcd_set_ep_cnt_rx_reg(__O uint16_t * pdwReg, size_t wCount)  {
-  unsigned int wNBlocks;
+  uint32_t wNBlocks;
   if(wCount > 62u)
   {
     wNBlocks = wCount >> 5u;
@@ -203,9 +203,9 @@ static inline void pcd_set_ep_cnt_rx_reg(__O uint16_t * pdwReg, size_t wCount)  
   * @param  bAddr Address.
   * @retval None
   */
-static inline void pcd_set_ep_address(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int bAddr)
+static inline void pcd_set_ep_address(USB_TypeDef * USBx,  uint32_t bEpNum, uint32_t bAddr)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= USB_EPREG_MASK;
   regVal |= bAddr;
   regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX;
@@ -220,31 +220,31 @@ static inline __IO uint16_t * pcd_btable_word_ptr(USB_TypeDef * USBx, size_t x)
 }
 
 // Pointers to the PMA table entries (using the ARM address space)
-static inline __IO uint16_t* pcd_ep_tx_address_ptr(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline __IO uint16_t* pcd_ep_tx_address_ptr(USB_TypeDef * USBx, uint32_t bEpNum)
 {
   return pcd_btable_word_ptr(USBx,(bEpNum)*4u + 0u);
 }
-static inline __IO uint16_t* pcd_ep_tx_cnt_ptr(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline __IO uint16_t* pcd_ep_tx_cnt_ptr(USB_TypeDef * USBx, uint32_t bEpNum)
 {
   return pcd_btable_word_ptr(USBx,(bEpNum)*4u + 1u);
 }
 
-static inline __IO uint16_t* pcd_ep_rx_address_ptr(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline __IO uint16_t* pcd_ep_rx_address_ptr(USB_TypeDef * USBx, uint32_t bEpNum)
 {
   return  pcd_btable_word_ptr(USBx,(bEpNum)*4u + 2u);
 }
 
-static inline __IO uint16_t* pcd_ep_rx_cnt_ptr(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline __IO uint16_t* pcd_ep_rx_cnt_ptr(USB_TypeDef * USBx, uint32_t bEpNum)
 {
   return pcd_btable_word_ptr(USBx,(bEpNum)*4u + 3u);
 }
 
-static inline void pcd_set_ep_tx_cnt(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int wCount)
+static inline void pcd_set_ep_tx_cnt(USB_TypeDef * USBx,  uint32_t bEpNum, uint32_t wCount)
 {
   *pcd_ep_tx_cnt_ptr(USBx, bEpNum) = (uint16_t)wCount;
 }
 
-static inline void pcd_set_ep_rx_cnt(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int wCount)
+static inline void pcd_set_ep_rx_cnt(USB_TypeDef * USBx,  uint32_t bEpNum, uint32_t wCount)
 {
   __IO uint16_t *pdwReg = pcd_ep_rx_cnt_ptr((USBx),(bEpNum));
   pcd_set_ep_cnt_rx_reg(pdwReg, wCount);
@@ -257,7 +257,7 @@ static inline void pcd_set_ep_rx_cnt(USB_TypeDef * USBx,  unsigned int bEpNum, u
   * @param  wState new state
   * @retval None
   */
-static inline void pcd_set_ep_tx_status(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int wState)
+static inline void pcd_set_ep_tx_status(USB_TypeDef * USBx,  uint32_t bEpNum, uint32_t wState)
 {
   uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= USB_EPTX_DTOGMASK;
@@ -284,7 +284,7 @@ static inline void pcd_set_ep_tx_status(USB_TypeDef * USBx,  unsigned int bEpNum
   * @retval None
   */
 
-static inline void pcd_set_ep_rx_status(USB_TypeDef * USBx,  unsigned int bEpNum, unsigned int wState)
+static inline void pcd_set_ep_rx_status(USB_TypeDef * USBx,  uint32_t bEpNum, uint32_t wState)
 {
   uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= USB_EPRX_DTOGMASK;
@@ -309,17 +309,17 @@ static inline void pcd_set_ep_rx_status(USB_TypeDef * USBx,  unsigned int bEpNum
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-static inline void pcd_rx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
+static inline void pcd_rx_dtog(USB_TypeDef * USBx,  uint32_t bEpNum)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= USB_EPREG_MASK;
   regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_RX;
   pcd_set_endpoint(USBx, bEpNum, regVal);
 }
 
-static inline void pcd_tx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
+static inline void pcd_tx_dtog(USB_TypeDef * USBx,  uint32_t bEpNum)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= USB_EPREG_MASK;
   regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_TX;
   pcd_set_endpoint(USBx, bEpNum, regVal);
@@ -332,18 +332,18 @@ static inline void pcd_tx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
   * @retval None
   */
 
-static inline void pcd_clear_rx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
+static inline void pcd_clear_rx_dtog(USB_TypeDef * USBx,  uint32_t bEpNum)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   if((regVal & USB_EP_DTOG_RX) != 0)
   {
     pcd_rx_dtog(USBx,bEpNum);
   }
 }
 
-static inline void pcd_clear_tx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
+static inline void pcd_clear_tx_dtog(USB_TypeDef * USBx,  uint32_t bEpNum)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   if((regVal & USB_EP_DTOG_TX) != 0)
   {
     pcd_tx_dtog(USBx,bEpNum);
@@ -357,17 +357,17 @@ static inline void pcd_clear_tx_dtog(USB_TypeDef * USBx,  unsigned int bEpNum)
   * @retval None
   */
 
-static inline void pcd_set_ep_kind(USB_TypeDef * USBx,  unsigned int bEpNum)
+static inline void pcd_set_ep_kind(USB_TypeDef * USBx,  uint32_t bEpNum)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal |= USB_EP_KIND;
   regVal &= USB_EPREG_MASK;
   regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX;
   pcd_set_endpoint(USBx, bEpNum, regVal);
 }
-static inline void pcd_clear_ep_kind(USB_TypeDef * USBx, unsigned int bEpNum)
+static inline void pcd_clear_ep_kind(USB_TypeDef * USBx, uint32_t bEpNum)
 {
-  unsigned int regVal = pcd_get_endpoint(USBx, bEpNum);
+  uint32_t regVal = pcd_get_endpoint(USBx, bEpNum);
   regVal &= USB_EPKIND_MASK;
   regVal |= USB_EP_CTR_RX|USB_EP_CTR_TX;
   pcd_set_endpoint(USBx, bEpNum, regVal);


### PR DESCRIPTION
ST FSDEV driver updates
* Small typo fix
* Convert many of the macros to use functions. Keeping lots of stuff as `unsigned int` let the number of type conversions be reduced, reducing the final binary size by about 350 bytes (with optimization enabled). Wow. This also makes the utility functions MUCH more readable. Before the rewrite of them, I couldn't understand what they were doing.
* Implement support for EP less than 64 bytes.

I still need to figure out if there are thread/locking issues regarding the globals, or how EPs can be accessed by multiple threads simultaneously. Are memory barriers needed? 

I've tested this by using it with the USBTMC class, but not much more than this.